### PR TITLE
whitelist ton.twitter.com

### DIFF
--- a/aumm.hosts
+++ b/aumm.hosts
@@ -406,7 +406,6 @@ thefappeningblog.com
 theporndude.com
 tilda.ws
 times25.go2affise.com
-ton.twitter.com
 tools.bongacams.com
 toptovar2020.ru
 totalcpi.com


### PR DESCRIPTION
Please whitelist ton.twitter.com
This domain is required for sharing images in Twitter DMs

Also can you please enable 'Issues' on this git so people can report issues without needing a pull request thanks
Thanks